### PR TITLE
Fixes an issue where yarn start would use old url

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -250,7 +250,7 @@ function watch() {
 
         browserSync.init({
             proxy: {
-                target: themeSettings.testSiteUrl,
+                target: answer.url,
                 proxyRes: [
                     function(_proxyRes: any, _req: any, res: any){
                         res.setHeader('Access-Control-Allow-Origin', '*');

--- a/theme-settings.ts
+++ b/theme-settings.ts
@@ -53,9 +53,9 @@ export class ThemeSettings {
 
         // This makes build decisions depending on bootstrap and fontawesome preferences.
         this.useBootstrap = 'all';
-        this.useFontAwesome = false;
+        this.useFontAwesome = true;
 
         // This saves the last used test site url.
-        this.testSiteUrl = "https://dnn.localtest.me";
+        this.testSiteUrl = "http://980.localtest.me";
     }
 }


### PR DESCRIPTION
The url was read from config before it was answered, this PR changes the logic to use the answer instead of the old config

Closes #187 