### PR TITLE
Cleans install folder before build

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -36,6 +36,7 @@ var semVer = {
 
 function clean(){
     return del([
+        './install/**/*',
         `../Skins/${themeSettings.packageName}/**/*`,
         `../Containers/${themeSettings.packageName}/**/*`
     ], {


### PR DESCRIPTION
The install folder was just growing after each build, it should only contain the current build. This PR cleans that folder before the build.

Closes #190